### PR TITLE
Upgrade to work with 2.99.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-lazy val extMetadataExtractorVersion = "2.50.1"
+lazy val extMetadataExtractorVersion = "2.50.11"
 
 name         := "metadata-extractor"
 organization := "com.xmlcalabash"
@@ -10,13 +10,13 @@ scalaVersion := "2.13.5"
 resolvers += "Restlet" at "https://maven.restlet.com"
 
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.32"
-libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.6"
-libraryDependencies += "com.xmlcalabash" % "xml-calabash_2.13" % "2.99.5"
+libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.7"
+libraryDependencies += "com.xmlcalabash" % "xml-calabash_2.13" % "2.99.11"
 libraryDependencies += "com.drewnoakes" % "metadata-extractor" % "2.16.0"
 libraryDependencies += "org.apache.pdfbox" % "pdfbox" % "2.0.24"
 libraryDependencies += "org.apache.pdfbox" % "xmpbox" % "2.0.24"
 libraryDependencies += "javax.xml.bind" % "jaxb-api" % "2.3.1"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.3" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.10" % "test"
 
 TaskKey[Unit]("myTask") := (Compile / runMain).toTask(" com.xmlcalabash.drivers.Main pipe.xpl").value

--- a/src/main/resources/com.xmlcalabash.properties
+++ b/src/main/resources/com.xmlcalabash.properties
@@ -1,3 +1,0 @@
-cx = namespace http://xmlcalabash.com/ns/extensions
-com.xmlcalabash.ext.metadataextractor.MetadataExtractor = step cx:metadata-extractor
-

--- a/src/main/resources/com.xmlcalabash.settings
+++ b/src/main/resources/com.xmlcalabash.settings
@@ -1,0 +1,2 @@
+namespace http://xmlcalabash.com/ns/extensions = cx
+step cx:metadata-extractor = com.xmlcalabash.ext.metadataextractor.MetadataExtractor

--- a/src/main/scala/com/xmlcalabash/ext/metadataextractor/MetadataException.scala
+++ b/src/main/scala/com/xmlcalabash/ext/metadataextractor/MetadataException.scala
@@ -1,6 +1,5 @@
 package com.xmlcalabash.ext.metadataextractor
 
-import com.jafpl.graph.Location
 import com.xmlcalabash.exceptions.XProcException
 import com.xmlcalabash.model.util.XProcConstants
 import net.sf.saxon.s9api.QName

--- a/src/main/scala/com/xmlcalabash/ext/metadataextractor/MetadataExtractor.scala
+++ b/src/main/scala/com/xmlcalabash/ext/metadataextractor/MetadataExtractor.scala
@@ -1,10 +1,9 @@
 package com.xmlcalabash.ext.metadataextractor
 
-import com.xmlcalabash.exceptions.XProcException
 import com.xmlcalabash.model.util.XProcConstants
-import com.xmlcalabash.runtime.{BinaryNode, StaticContext, XProcMetadata, XmlPortSpecification}
+import com.xmlcalabash.runtime.{BinaryNode, XProcMetadata, XmlPortSpecification}
 import com.xmlcalabash.steps.DefaultXmlStep
-import com.xmlcalabash.util.{MediaType, TypeUtils}
+import com.xmlcalabash.util.{MediaType, MinimalStaticContext}
 import net.sf.saxon.s9api.{QName, XdmNode, XdmValue}
 
 import java.nio.charset.StandardCharsets
@@ -33,7 +32,7 @@ class MetadataExtractor extends DefaultXmlStep {
     }
   }
 
-  override def run(context: StaticContext): Unit = {
+  override def run(context: MinimalStaticContext): Unit = {
     super.run(context)
 
     val assert = booleanBinding(_assert_metadata).getOrElse(false)

--- a/src/test/resources/pipe.xpl
+++ b/src/test/resources/pipe.xpl
@@ -1,0 +1,22 @@
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
+                exclude-inline-prefixes="cx xs"
+                version="3.0">
+
+<p:output port="result"/>
+
+<p:declare-step type="cx:metadata-extractor">
+  <p:input port="source" content-types="any"/>
+  <p:output port="result" content-types="xml" sequence="true"/>
+  <p:option name="assert-metadata" as="xs:boolean" select="false()"/>
+  <p:option name="properties" as="map(xs:QName,item()*)"/>
+</p:declare-step>
+
+<cx:metadata-extractor properties="map { 'password': 'this is sekrit' }">
+  <p:with-input>
+    <p:document href="document.pdf"/>
+  </p:with-input>
+</cx:metadata-extractor>
+
+</p:declare-step>

--- a/src/test/scala/com/xmlcalabash/metadataextractor/PipelineSpec.scala
+++ b/src/test/scala/com/xmlcalabash/metadataextractor/PipelineSpec.scala
@@ -1,0 +1,42 @@
+package com.xmlcalabash.metadataextractor
+
+import com.jafpl.messages.Message
+import com.jafpl.steps.DataConsumer
+import com.xmlcalabash.XMLCalabash
+import com.xmlcalabash.messages.XdmNodeItemMessage
+import com.xmlcalabash.model.util.XProcConstants
+import com.xmlcalabash.util.{PipelineOutputConsumer, S9Api}
+import org.scalatest.flatspec.AnyFlatSpec
+
+class PipelineSpec extends AnyFlatSpec {
+  "Running pipe.xpl " should " produce XML metadata" in {
+    val calabash = XMLCalabash.newInstance()
+    val xml = new Consumer()
+    val result = new PipelineOutputConsumer("result", xml)
+    calabash.args.parse(List("src/test/resources/pipe.xpl"))
+    calabash.parameter(result)
+    calabash.configure()
+    calabash.run()
+    if (xml.message.isDefined) {
+      xml.message.get match {
+        case msg: XdmNodeItemMessage =>
+          val root = S9Api.documentElement(msg.item)
+          assert(root.isDefined)
+          assert(root.get.getNodeName == XProcConstants.c_result)
+        case _ => fail()
+      }
+    } else {
+      fail()
+    }
+  }
+
+  private class Consumer extends DataConsumer {
+    var _message = Option.empty[Message]
+
+    def message: Option[Message] = _message
+
+    override def consume(port: String, message: Message): Unit = {
+      _message = Some(message)
+    }
+  }
+}


### PR DESCRIPTION
This PR updates the APIs to work with XML Calabash 2.99.11 and adds a unit test to run the step.